### PR TITLE
Fix desktop file key

### DIFF
--- a/data/dekstop-file-editor.desktop
+++ b/data/dekstop-file-editor.desktop
@@ -7,4 +7,4 @@ Categories=Utility;GTK;
 MimeType=application/x-desktop;
 Comment=Create new or change existing desktop entry
 Icon=applications-other
-NoDisplay=False
+NoDisplay=false


### PR DESCRIPTION
desktop-file-validate: /usr/share/applications/dekstop-file-editor.desktop: error: value "False" for boolean key "NoDisplay" in group "Desktop Entry" contains invalid characters, boolean values must be "false" or "true"