### PR TITLE
Add LXQt to NotShowIn list in desktop files

### DIFF
--- a/data/jwm-settings-manager-autostart.desktop
+++ b/data/jwm-settings-manager-autostart.desktop
@@ -11,4 +11,4 @@ Exec=jwm-settings-manager --autostart
 Terminal=false
 Type=Application
 Categories=Settings;System;
-NotShowIn=GNOME;KDE;LXDE;MATE;Razor;TDE;Unity;XFCE;EDE;Cinnamon;
+NotShowIn=GNOME;KDE;LXDE;LXQt;MATE;Razor;TDE;Unity;XFCE;EDE;Cinnamon;

--- a/data/jwm-settings-manager-desktop.desktop
+++ b/data/jwm-settings-manager-desktop.desktop
@@ -10,4 +10,4 @@ Exec=jwm-settings-manager --desktop
 Terminal=false
 Type=Application
 Categories=Settings;System;
-NotShowIn=GNOME;KDE;LXDE;MATE;Razor;TDE;Unity;XFCE;EDE;Cinnamon;
+NotShowIn=GNOME;KDE;LXDE;LXQt;MATE;Razor;TDE;Unity;XFCE;EDE;Cinnamon;

--- a/data/jwm-settings-manager-fonts.desktop
+++ b/data/jwm-settings-manager-fonts.desktop
@@ -11,4 +11,4 @@ Exec=jwm-settings-manager --font
 Terminal=false
 Type=Application
 Categories=Settings;System;
-NotShowIn=GNOME;KDE;LXDE;MATE;Razor;TDE;Unity;XFCE;EDE;Cinnamon;
+NotShowIn=GNOME;KDE;LXDE;LXQt;MATE;Razor;TDE;Unity;XFCE;EDE;Cinnamon;

--- a/data/jwm-settings-manager-icons.desktop
+++ b/data/jwm-settings-manager-icons.desktop
@@ -11,4 +11,4 @@ Exec=jwm-settings-manager --icons
 Terminal=false
 Type=Application
 Categories=Settings;System;
-NotShowIn=GNOME;KDE;LXDE;MATE;Razor;TDE;Unity;XFCE;EDE;Cinnamon;
+NotShowIn=GNOME;KDE;LXDE;LXQt;MATE;Razor;TDE;Unity;XFCE;EDE;Cinnamon;

--- a/data/jwm-settings-manager-keyboard.desktop
+++ b/data/jwm-settings-manager-keyboard.desktop
@@ -11,4 +11,4 @@ Exec=jwm-settings-manager --keyboard
 Terminal=false
 Type=Application
 Categories=Settings;System;
-NotShowIn=GNOME;KDE;LXDE;MATE;Razor;TDE;Unity;XFCE;EDE;Cinnamon;
+NotShowIn=GNOME;KDE;LXDE;LXQt;MATE;Razor;TDE;Unity;XFCE;EDE;Cinnamon;

--- a/data/jwm-settings-manager-mouse.desktop
+++ b/data/jwm-settings-manager-mouse.desktop
@@ -11,4 +11,4 @@ Exec=fltk-mouse
 Terminal=false
 Type=Application
 Categories=Settings;System;
-NotShowIn=GNOME;KDE;LXDE;MATE;Razor;TDE;Unity;XFCE;EDE;Cinnamon;
+NotShowIn=GNOME;KDE;LXDE;LXQt;MATE;Razor;TDE;Unity;XFCE;EDE;Cinnamon;

--- a/data/jwm-settings-manager-panel.desktop
+++ b/data/jwm-settings-manager-panel.desktop
@@ -11,4 +11,4 @@ Exec=jwm-settings-manager --panel
 Terminal=false
 Type=Application
 Categories=Settings;System;
-NotShowIn=GNOME;KDE;LXDE;MATE;Razor;TDE;Unity;XFCE;EDE;Cinnamon;
+NotShowIn=GNOME;KDE;LXDE;LXQt;MATE;Razor;TDE;Unity;XFCE;EDE;Cinnamon;

--- a/data/jwm-settings-manager-themes.desktop
+++ b/data/jwm-settings-manager-themes.desktop
@@ -11,4 +11,4 @@ Exec=jwm-settings-manager --themes
 Terminal=false
 Type=Application
 Categories=Settings;System;
-NotShowIn=GNOME;KDE;LXDE;MATE;Razor;TDE;Unity;XFCE;EDE;Cinnamon;
+NotShowIn=GNOME;KDE;LXDE;LXQt;MATE;Razor;TDE;Unity;XFCE;EDE;Cinnamon;

--- a/data/jwm-settings-manager-window.desktop
+++ b/data/jwm-settings-manager-window.desktop
@@ -11,4 +11,4 @@ Exec=jwm-settings-manager --window
 Terminal=false
 Type=Application
 Categories=Settings;System;
-NotShowIn=GNOME;KDE;LXDE;MATE;Razor;TDE;Unity;XFCE;EDE;Cinnamon;
+NotShowIn=GNOME;KDE;LXDE;LXQt;MATE;Razor;TDE;Unity;XFCE;EDE;Cinnamon;

--- a/data/jwm-settings-manager.desktop
+++ b/data/jwm-settings-manager.desktop
@@ -17,4 +17,4 @@ Exec=jwm-settings-manager
 Terminal=false
 Type=Application
 Categories=Settings;System;
-NotShowIn=GNOME;KDE;LXDE;MATE;Razor;TDE;Unity;XFCE;EDE;Cinnamon;
+NotShowIn=GNOME;KDE;LXDE;LXQt;MATE;Razor;TDE;Unity;XFCE;EDE;Cinnamon;

--- a/data/jwm-settings-manager.desktop.in
+++ b/data/jwm-settings-manager.desktop.in
@@ -17,4 +17,4 @@ Exec=@EXEC@
 Terminal=false
 Type=Application
 Categories=Settings;System;
-NotShowIn=GNOME;KDE;LXDE;MATE;Razor;TDE;Unity;XFCE;EDE;Cinnamon;
+NotShowIn=GNOME;KDE;LXDE;LXQt;MATE;Razor;TDE;Unity;XFCE;EDE;Cinnamon;


### PR DESCRIPTION
LXQt is missing in the `NotShowIn` list in desktop files.